### PR TITLE
Aadd apply event to aggregate type

### DIFF
--- a/pkg/cqrs/cqrs.go
+++ b/pkg/cqrs/cqrs.go
@@ -21,6 +21,7 @@ type Aggregate interface {
 	Load(<-chan *rangedb.Record)
 	Handle(Command) []rangedb.Event
 	CommandTypes() []string
+	ApplyEvent(event rangedb.Event)
 }
 
 type cqrs struct {

--- a/pkg/cqrs/cqrs.go
+++ b/pkg/cqrs/cqrs.go
@@ -78,6 +78,14 @@ func (c *cqrs) Dispatch(command Command) []rangedb.Event {
 	streamName := rangedb.GetEventStream(command)
 	eventStream := c.store.EventsByStreamStartingWith(context.Background(), 0, streamName)
 	commandHandler.Load(eventStream)
+
+	// Why can we can't do this here?
+	//for record := range eventStream {
+	//	if event, ok := record.Data.(rangedb.Event); ok {
+	//		u.ApplyEvent(event)
+	//	}
+	//}
+
 	handlerEvents := commandHandler.Handle(command)
 
 	events := append(preHandlerEvents, handlerEvents...)


### PR DESCRIPTION
Assume that I have no clue what I am doing, my apologies for my ignorance.

Most CQRS framework that I personally messed around with has some sort of `ApplyEvent` callback, taking https://hexdocs.pm/commanded/aggregates.html#state-mutators as an inspiration.

Although today we can accomplish that by doing https://github.com/inklabs/rangedb/blob/503b26043b10c92d97be5e0f25152a06bc47667a/examples/chat/user_aggregate.go#L58

I would rather have the function to be the exact same name and bring alignment before people use any random function increasing entropy between projects.